### PR TITLE
docs(readme): update github releases shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @myparcel/constants
 
 [![npm](https://img.shields.io/npm/v/@myparcel/constants?labelColor=27272A&logoColor=FFFFFF&style=for-the-badge&color=CC3534&logo=npm)](https://www.npmjs.com/package/@myparcel/constants/)
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/myparcelnl/js-sdk?labelColor=27272A&style=for-the-badge)](https://github.com/myparcelnl/js-sdk/releases)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/myparcelnl/constants?labelColor=27272A&style=for-the-badge)](https://github.com/myparcelnl/constants/releases)
 
 This package contains various constant values used in the MyParcel ecosystem.
 


### PR DESCRIPTION
It was defined as 3.0.0, but that was pointed to the js-sdk.